### PR TITLE
Fixes for u.ie9.js

### DIFF
--- a/src/u.ie9.js
+++ b/src/u.ie9.js
@@ -2,6 +2,12 @@
 (function(u,window,document) {
   'use strict';
 
+  /**
+   * wait for body to be available
+   * insert function call at beginning of list to execute it before any other registered function
+   */
+  u._deferredInitHandlers.unshift(function () {
+
 
   /**
    * overwrite class methods if classList is not defined
@@ -66,5 +72,7 @@
     };
 
   }
+
+  });
 
 })(u,window,document);

--- a/src/u.ie9.js
+++ b/src/u.ie9.js
@@ -26,7 +26,7 @@
      * @return {object} this
      */
     u.fn.addClass = function(cls) {
-      return this.each(function(el) {
+      return this.each(function(i, el) {
         el.className += ' ' + cls;
       });
     };
@@ -38,7 +38,7 @@
      * @return {object} this
      */
     u.fn.removeClass = function(cls) {
-      return this.each(function(el) {
+      return this.each(function(i, el) {
         el.className = el.className.replace(new RegExp('(^|\\b)' + cls.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
       });
     };
@@ -50,7 +50,7 @@
      * @return {object} this
      */
     u.fn.toggleClass = function(cls) {
-      return this.each(function(el) {
+      return this.each(function(i, el) {
         var classes = el.className.split(' '),
             existingIndex = classes.indexOf(cls);
 

--- a/src/u.js
+++ b/src/u.js
@@ -18,8 +18,15 @@
    * @return {(object|undefined)}             instance or execute function on dom ready
    */
   win.u = function(arg) {
-    return /^f/.test(typeof arg) ? /c/.test(doc.readyState) ? arg() : u(doc).on('DOMContentLoaded', arg) : new Init(arg);
+    return /^f/.test(typeof arg) ? /c/.test(doc.readyState) ? arg() : u._deferredInitHandlers.push(arg) : new Init(arg);
   };
+
+
+  /**
+   * list of deferred intializer functions
+   * will be called in the given order on DOMContentLoaded and emptied afterwards
+   */
+  u._deferredInitHandlers = [];
 
 
   /**
@@ -1210,5 +1217,16 @@
    * @type {object}
    */
   win.µ = u;
+
+
+  /**
+   * call functions registered with u(func)
+   */
+  u(doc).on('DOMContentLoaded', function (e) {
+    for (var i = 0; i < u._deferredInitHandlers.length; i++) {
+      u._deferredInitHandlers[i](e);
+    }
+    u._deferredInitHandlers = [];
+  });
 
 })(window, document, [], 'prototype');


### PR DESCRIPTION
When using `u.ie9.js`, `document.body` was undefined at the time the script was executing, because the DOM was not fully loaded. My first attempt was to wrap the definition of the override methods inside a `DOMContentLoaded` event listener, so the body would be available. But, it needed to execute before all other user defined init handlers (registered with `u(func)`). So I defined an ordered list of init handlers in `u.js`. Instead of binding them directly to `DOMContentLoaded`, the handlers are now added to the list and executed within a single `DOMContentLoaded` listener. This gives `u.ie9.js` the change to add its handler at the beginning of the list.
Additionally, the index arguments of the iterator callbacks were missing.
